### PR TITLE
fix: harden Cognitum Spaces evidence boundary

### DIFF
--- a/docs/adr/ADR-402-ruview-cognitum-spaces-spatial-intelligence.md
+++ b/docs/adr/ADR-402-ruview-cognitum-spaces-spatial-intelligence.md
@@ -1,8 +1,8 @@
 # ADR-402 — RuView + Cognitum Spaces: the spatial-intelligence layer
 
-- Status: **Proposed** (design-only — RuView & Cognitum Spaces are external
-  repos/products; this ADR specifies the layer and its seam onto the mesh, it
-  does NOT claim implementation in `radio-moe`)
+- Status: **Accepted** (the read-side adapter and fail-closed seam are
+  implemented in `radio-moe`; write-side synchronization and the 30-day
+  operational acceptance test remain separately gated rollout work)
 - Date: 2026-08-16
 - Related: ADR-401 (Perpetual Intelligence Machine — this is capability 8
   expanded), ADR-397 (streaming mixture), ADR-399 (midstream, RVM/RVF),
@@ -17,27 +17,36 @@ change, predicts what happens next, and coordinates governed actions.**
 Together they form a continuously-learning intelligence layer for **physical
 environments**.
 
-**Boundary (honest):** RuView, RuField, and Cognitum Spaces are *not* in this
-repository. What already exists here is the **fusion + governance substrate**
-they plug into — the streaming mixture (`mixture.ts`), the independence-weighted
-quorum + action gate (`lineage-independence.ts`, `action-gate.ts`), signed
-failover (`failover.ts`), the witnessed trajectory ledger (`rvf-trajectory.ts`),
-and the midstream observation adapter (`midstream-adapter`). This ADR defines
-the contract so the perception layers drop in without redesign.
+**Repository boundary:** RuView and Cognitum Spaces are external products. This
+repository owns the read adapter, typed observation admission, derived-lineage
+handling, fusion, and governance substrate they plug into — the streaming
+mixture (`mixture.ts`), independence-weighted quorum + action gate
+(`lineage-independence.ts`, `action-gate.ts`), signed failover (`failover.ts`),
+and witnessed trajectory ledger (`rvf-trajectory.ts`). It does not own OAuth
+issuance, the Spaces resource server, RuView sensing, or production deployment.
 
-**Update (2026-08-16) — Cognitum Spaces is DEPLOYED and now has a live adapter.**
-Cognitum Spaces runs on GCP (`spacesapi` Cloud Run, `GET /v1/spaces`, `cog_`-key /
-Bearer authed). `packages/radio-moe/src/cognitum-spaces.ts` (`CognitumSpacesClient`)
-connects the mesh to it and maps a Cognitum Spaces **Envelope** →
-a radio-moe `Observation` (`spacesEnvelopeToObservation`) so real spatial state
-flows through the ADR-402 `admitObservation` fail-closed admission. Auth is the
-caller's `cog_` key or a Bearer token from the Cognitum `identity` service
-(obtaining the key is the user's sign-in — an out-of-band step, never minted here).
-**Verified live** (`test/cognitum-spaces.test.ts` LIVE case, gated on
-`COGNITUM_API_KEY`): `GET /v1/spaces` → 200, and the service reports a `boundary`
-that **excludes `raw_csi`, `recordings`, `pose_frames`, `vital_waveforms`,
-`identity_observations` from the cloud** — the "raw sensing stays local" rule,
-enforced at the edge and confirmed against the running service.
+**Update (2026-08-17) — the deployed read surface and adapter are verified.**
+`packages/radio-moe/src/cognitum-spaces.ts` connects to the gateway route
+`GET /v1/spaces`, validates the response contract, and maps a Cognitum Spaces
+Envelope to a derived radio-moe `Observation`. Authentication is either a
+compatibility `cog_` key read from `COGNITUM_SPACES_API`, or a Cognitum OAuth
+access token issued to the RuView public PKCE client with audience/client
+`ruview` and scope `spaces:read`. A `cognitum-cli` session-exchange token is a
+different credential and MUST NOT be reused for Spaces.
+
+The live API-key compatibility test returned 200 and a service `boundary` that
+excludes `raw_csi`, `cir`, `rf_tensors`, `recordings`, `pose_frames`,
+`vital_waveforms`, and `identity_observations` from cloud synchronization. The
+test is gated on `COGNITUM_SPACES_API`; secret values are never logged or
+committed. OAuth rollout is coordinated by Cognitum API ADR-094 and RuView
+ADR-325 and is not claimed live until those deployments are verified.
+
+The adapter preserves tenant, message, sequence, and provenance lineage.
+Spaces-derived state is explicitly `derived` and is capped at
+`update-world-model`, regardless of confidence, preventing a cloud recollection
+from returning as apparently independent workflow authority. Missing
+confidence remains unknown (`NaN`) and missing `modelVersion` remains missing
+calibration; provenance is never used as a calibration substitute.
 
 ## Functional architecture
 
@@ -169,7 +178,7 @@ the same false-consensus guard ADR-401 makes constitutional, applied to sensors.
 | ≥95% calibrated presence accuracy | RuView calibration + RuField typed obs | **External (RuView) — bench gap** |
 | Peer-failure detection <5s | `bench-failover.ts` (shared with ADR-401) | Protocol recovery **measured** (p50 0.34 ms at 30% loss, ≈8000× under budget); sensor/network detection latency is the external part |
 | 50% false-alert reduction via fusion | `bench-false-alert.ts` + `test/false-alert.test.ts` (corroboration fusion vs no-fusion any-sensor baseline) | **Built & measured** — 58.3% reduction (60%→25%), detection retained 100% |
-| Raw sensing data stays local | Cognitum Spaces `boundary` (live) + sovereign-peer boundary (ADR-401 cap 6) | **Verified on the deployed service** — `/v1/spaces` boundary excludes raw_csi/recordings/pose_frames/vital_waveforms/identity_observations from the cloud |
+| Raw sensing data stays local | Cognitum Spaces `boundary` (live) + sovereign-peer boundary (ADR-401 cap 6) | **Verified on the deployed read service** — `/v1/spaces` excludes raw_csi/cir/rf_tensors/recordings/pose_frames/vital_waveforms/identity_observations from cloud synchronization; write-side enforcement remains a separate gate |
 | Complete receipt per external action | `action-gate.ts` + `rvf-trajectory.ts` | Built (action side); wire perception provenance in |
 
 ## Decision
@@ -183,15 +192,21 @@ the same false-consensus guard ADR-401 makes constitutional, applied to sensors.
    requires source identity, location, kind, confidence, privacy class,
    calibration version, and a bounded/current expiry window; missing or malformed
    any of these → **inadmissible** (fail-closed — unknown stays unknown), with a
-   per-field rejection reason. Optional sensor-health floor. `confidenceTier`
+   per-field rejection reason. Optional sensor-health floor. Derived lineage is
+   runtime-validated and Spaces recollections are restricted to world-model
+   updates, closing the feedback-laundering path. `confidenceTier`
    maps ADR-402 §5 (low → update-world-model, medium → request-more-sensing, high
    → authorized-workflow), with the top tier documented as *eligibility only* —
    an authorized action still requires independent corroboration at the
    `ActionGate` (graded quorum). Proven by `test/observation.test.ts` (6 tests).
-3. **Remaining ADR-402 loop items** (this ADR is otherwise a specification): the
-   timed failover bench (**done**, shared with ADR-401), the fusion false-alert
-   bench (**done** — `bench-false-alert.ts`), and the sovereign-peer local-data
-   boundary (the one still open, part of ADR-401 cap 6).
+3. **Credential boundaries are explicit.** The generic Cognitum CLI session
+   helper remains available only to services accepting the `cognitum-cli`
+   audience. Spaces requires RuView PKCE + `spaces:read`; compatibility API keys
+   remain read from a Spaces-specific environment variable.
+4. **Remaining ADR-402 loop items:** the timed failover bench (**done**, shared
+   with ADR-401), the fusion false-alert bench (**done** —
+   `bench-false-alert.ts`), the sovereign-peer local-data boundary (open under
+   ADR-401 capability 6), and the explicitly authorized write-side exchange.
 
 ## Consequences
 

--- a/packages/radio-moe/src/cognitum-identity.ts
+++ b/packages/radio-moe/src/cognitum-identity.ts
@@ -4,16 +4,16 @@
 //! `POST /v1/cli/session/exchange` completes a user login and issues a Bearer
 //! access token (+ refresh token, org/workspace scope); `GET /v1/cli/services`
 //! lists the services that token may use. This module is the client for that
-//! flow — a user exchanges their session and the resulting token plugs straight
-//! into the Cognitum Spaces client (`bearerAuth`), so the mesh uses Cognitum
-//! services under the user's own authenticated identity.
+//! flow. Its `cognitum-cli` token is intentionally distinct from the RuView PKCE
+//! access token required by Cognitum Spaces. Callers must not pass the exchange
+//! token to the Spaces client merely because both are Bearer credentials.
 //!
 //! Boundary (honest): the exchange completes a login the USER performs (browser
 //! sign-in bootstrap); this client sends the exchange request and consumes the
 //! token. It never mints tokens or holds user passwords — obtaining the session
 //! is the user's out-of-band sign-in.
 
-import { bearerAuth, type CognitumAuth, type FetchLike } from './cognitum-spaces.js';
+import { bearerAuth, type CognitumAuth, type CognitumFetchLike } from './cognitum-spaces.js';
 
 const DEFAULT_IDENTITY_BASE_URL = 'https://identity-186366152200.us-central1.run.app';
 
@@ -42,7 +42,7 @@ export interface CliSession {
 
 export interface CognitumIdentityConfig {
   baseUrl?: string;
-  fetchImpl?: FetchLike;
+  fetchImpl?: CognitumFetchLike;
 }
 
 export class CognitumIdentityClient {
@@ -51,8 +51,8 @@ export class CognitumIdentityClient {
     this.baseUrl = (cfg.baseUrl ?? DEFAULT_IDENTITY_BASE_URL).replace(/\/$/, '');
   }
 
-  private get fetchImpl(): FetchLike {
-    return this.cfg.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
+  private get fetchImpl(): CognitumFetchLike {
+    return this.cfg.fetchImpl ?? (globalThis.fetch as unknown as CognitumFetchLike);
   }
 
   /** Complete a user's CLI login → a Bearer session (POST /v1/cli/session/exchange). */
@@ -100,7 +100,11 @@ export class CognitumIdentityClient {
   }
 }
 
-/** Turn a completed session into a Cognitum auth for the Spaces/services clients. */
+/**
+ * Turn a CLI exchange session into auth for services that accept the
+ * `cognitum-cli` audience. Spaces does not: it requires a `ruview` PKCE token
+ * with `spaces:read`, so callers must not pass this auth to Spaces.
+ */
 export function sessionAuth(session: Pick<CliSession, 'accessToken'>): CognitumAuth {
   return bearerAuth(() => session.accessToken);
 }

--- a/packages/radio-moe/src/cognitum-spaces.ts
+++ b/packages/radio-moe/src/cognitum-spaces.ts
@@ -2,17 +2,18 @@
 //! service (ADR-402's world-model layer, made real).
 //!
 //! ADR-402 specified Cognitum Spaces as the external spatial world-model the mesh
-//! plugs into. It is deployed on GCP (`spacesapi` Cloud Run; gateway route
-//! `GET /v1/spaces`), `cog_`-key / Bearer authed. This adapter reads spatial twin
+//! plugs into. It is deployed behind the Cognitum API gateway at
+//! `GET /v1/spaces`. This adapter reads spatial twin
 //! state over that REST surface and maps a Cognitum Spaces **Envelope** to a
 //! radio-moe **Observation**, so real spatial state flows through `admitObservation`
 //! (the same fail-closed admission — no fact without confidence/privacy/expiry).
 //!
-//! Auth ("Cognitum OAuth for users") is supplied by the caller: a `cog_` API key
-//! (`X-API-Key`) or a Bearer token (a Firebase ID / OAuth access token from the
-//! Cognitum `identity` service). Keys are read from the environment AT CALL TIME —
-//! never hardcoded, never logged. `hasCredentials()` lets a caller skip cleanly
-//! when no key is configured.
+//! Auth is supplied by the caller: a compatibility `cog_` API key (`X-API-Key`)
+//! or a Cognitum OAuth access token issued to the `ruview` public PKCE client
+//! with audience/client `ruview` and scope `spaces:read`. A generic Firebase ID
+//! token or `cognitum-cli` session token is not a Spaces credential. Keys are
+//! read from the environment AT CALL TIME — never hardcoded, never logged.
+//! `hasCredentials()` lets a caller skip cleanly when no credential is configured.
 
 import type { Observation, PrivacyClass } from './observation.js';
 
@@ -23,11 +24,11 @@ export type CognitumAuth = () => Record<string, string>;
 export function apiKeyAuth(getKey: () => string | undefined): CognitumAuth {
   return () => {
     const k = getKey();
-    return k ? { 'x-api-key': k } : {};
+    return k?.startsWith('cog_') ? { 'x-api-key': k } : {};
   };
 }
 
-/** Bearer-token auth (Firebase ID token / OAuth access token from `identity`). */
+/** Bearer auth; callers must supply a RuView OAuth `spaces:read` access token. */
 export function bearerAuth(getToken: () => string | undefined): CognitumAuth {
   return () => {
     const t = getToken();
@@ -35,42 +36,59 @@ export function bearerAuth(getToken: () => string | undefined): CognitumAuth {
   };
 }
 
-/** Convenience: read a `cog_` key from an env var (default COGNITUM_API_KEY). */
-export function envApiKeyAuth(envVar = 'COGNITUM_API_KEY'): CognitumAuth {
+/** Convenience: read a `cog_` key from `COGNITUM_SPACES_API` by default. */
+export function envApiKeyAuth(envVar = 'COGNITUM_SPACES_API'): CognitumAuth {
   return apiKeyAuth(() => process.env[envVar]);
 }
 
-export type FetchLike = (
+export type CognitumFetchLike = (
   input: string,
-  init: { method: string; headers: Record<string, string>; body?: string },
-) => Promise<{ ok: boolean; status: number; json(): Promise<unknown>; text(): Promise<string> }>;
+  init: { method: string; headers: Record<string, string>; body?: string; signal?: AbortSignal; redirect?: 'error' | 'follow' | 'manual' },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  headers?: { get(name: string): string | null };
+  body?: { getReader(): { read(): Promise<{ done: boolean; value?: Uint8Array }>; cancel?(): Promise<void> } } | null;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}>;
 
 export interface CognitumSpacesConfig {
-  /** Default: the deployed `spacesapi` service (serves `/v1/spaces` directly).
-   *  Override to route through the API gateway or a staging deployment. */
+  /** Default: the Cognitum API gateway. Direct service origins are not public. */
   baseUrl?: string;
   auth: CognitumAuth;
   /** Injectable for tests; defaults to global fetch. */
-  fetchImpl?: FetchLike;
+  fetchImpl?: CognitumFetchLike;
+  timeoutMs?: number;
+  maxResponseBytes?: number;
 }
 
-/** The deployed Cognitum Spaces service (verified live: `GET /v1/spaces` → 200
- *  with a cog_ key). Override via `baseUrl` for gateway/staging routing. */
-const DEFAULT_BASE_URL = 'https://spacesapi-186366152200.us-central1.run.app';
+/** The deployed Cognitum Spaces gateway route (verified live with a `cog_` key). */
+const DEFAULT_BASE_URL = 'https://api.cognitum.one';
+const DEFAULT_TIMEOUT_MS = 10_000;
+const DEFAULT_MAX_RESPONSE_BYTES = 1024 * 1024;
+const MAX_CONFIGURED_RESPONSE_BYTES = 8 * 1024 * 1024;
+const MAX_SPACES = 100;
+const REQUIRED_EXCLUSIONS = [
+  'raw_csi', 'cir', 'rf_tensors', 'recordings', 'pose_frames',
+  'vital_waveforms', 'identity_observations',
+] as const;
 
 /** A spatial twin as returned by `GET /v1/spaces` (fields typed loosely — the
  *  service owns the schema; we map the stable ones). */
 export interface CognitumSpaceTwin {
-  spaceId?: string;
-  siteId?: string;
-  deviceId?: string;
+  id: string;
+  tenantId: string;
+  workspaceId?: string | null;
+  siteId: string;
+  name: string;
   connection?: 'connected' | 'degraded' | 'offline' | 'unknown';
-  twinStatus?: 'live' | 'delayed' | 'stale' | 'unavailable';
+  status?: 'live' | 'delayed' | 'stale' | 'unavailable';
   observedAt?: string | null;
   expiresAt?: string | null;
-  confidence?: number;
   privacy?: 'P2' | 'P3';
-  provenance?: string;
+  state: { confidence: number | null; occupancy: number | null; classification: 'P2'; [k: string]: unknown };
+  provenance: Record<string, unknown>;
   [k: string]: unknown;
 }
 
@@ -94,12 +112,44 @@ export interface CognitumSpacesEnvelope {
 export class CognitumSpacesClient {
   private readonly baseUrl: string;
   constructor(private readonly cfg: CognitumSpacesConfig) {
-    this.baseUrl = (cfg.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, '');
+    const url = new URL(cfg.baseUrl ?? DEFAULT_BASE_URL);
+    const loopback = url.hostname === 'localhost' || url.hostname === '127.0.0.1' || url.hostname === '[::1]';
+    if (url.protocol !== 'https:' && !(url.protocol === 'http:' && loopback)) {
+      throw new Error('cognitum spaces: HTTPS required');
+    }
+    if (url.username || url.password || url.search || url.hash) {
+      throw new Error('cognitum spaces: invalid base URL');
+    }
+    const timeoutMs = cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    if (!Number.isSafeInteger(timeoutMs) || timeoutMs < 1 || timeoutMs > 60_000) {
+      throw new Error('cognitum spaces: invalid timeout');
+    }
+    const maxResponseBytes = cfg.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES;
+    if (!Number.isSafeInteger(maxResponseBytes) || maxResponseBytes < 1024 || maxResponseBytes > MAX_CONFIGURED_RESPONSE_BYTES) {
+      throw new Error('cognitum spaces: invalid response limit');
+    }
+    this.baseUrl = url.toString().replace(/\/$/, '');
   }
 
   /** True when auth headers are present (a key/token is configured). */
   hasCredentials(): boolean {
-    return Object.keys(this.cfg.auth()).length > 0;
+    try { return Object.keys(this.authHeaders()).length > 0; } catch { return false; }
+  }
+
+  private authHeaders(): Record<string, string> {
+    const supplied = this.cfg.auth();
+    const apiKey = supplied['x-api-key'];
+    const bearer = supplied.authorization;
+    if (apiKey !== undefined && bearer !== undefined) throw new Error('cognitum spaces: ambiguous credentials');
+    if (apiKey !== undefined) {
+      if (!apiKey.startsWith('cog_') || /[\r\n]/.test(apiKey)) throw new Error('cognitum spaces: invalid API key');
+      return { 'x-api-key': apiKey };
+    }
+    if (bearer !== undefined) {
+      if (!/^Bearer [^\s]+$/.test(bearer)) throw new Error('cognitum spaces: invalid bearer token');
+      return { authorization: bearer };
+    }
+    return {};
   }
 
   /** GET /v1/spaces — the caller's authorized spatial twins. Returns just the
@@ -112,23 +162,32 @@ export class CognitumSpacesClient {
    *  `boundary` (what raw sensing it deliberately excludes from the cloud — the
    *  ADR-402 "raw sensing stays local" enforcement, verifiable at the edge). */
   async listSpacesResult(): Promise<SpacesListResult> {
-    const fetchImpl = this.cfg.fetchImpl ?? (globalThis.fetch as unknown as FetchLike);
-    const res = await fetchImpl(`${this.baseUrl}/v1/spaces`, {
-      method: 'GET',
-      headers: { accept: 'application/json', ...this.cfg.auth() },
-    });
+    const fetchImpl = this.cfg.fetchImpl ?? (globalThis.fetch as unknown as CognitumFetchLike);
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), this.cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+    let res;
+    try {
+      res = await fetchImpl(`${this.baseUrl}/v1/spaces`, {
+        method: 'GET',
+        headers: { accept: 'application/json', ...this.authHeaders() },
+        signal: controller.signal,
+        redirect: 'error',
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
     if (!res.ok) {
-      const detail = await res.text().catch(() => '');
+      const detail = (await res.text().catch(() => '')).slice(0, 256).replace(/[\r\n\0]/g, ' ');
       throw new Error(`cognitum spaces: HTTP ${res.status} ${detail}`.trim());
     }
-    const body = (await res.json()) as Record<string, unknown> | CognitumSpaceTwin[];
-    // Real shape: { object:'list', data:[...], boundary:{...} }. Tolerate a bare
-    // array and a legacy `spaces` key.
-    const data = Array.isArray(body)
-      ? body
-      : ((body.data as CognitumSpaceTwin[] | undefined) ?? (body.spaces as CognitumSpaceTwin[] | undefined) ?? []);
-    const boundary = !Array.isArray(body) ? (body.boundary as SpacesBoundary | undefined) : undefined;
-    return { data, ...(boundary ? { boundary } : {}) };
+    const contentType = res.headers?.get('content-type');
+    if (contentType !== undefined && contentType !== null && !/(?:application\/json|\+json)(?:\s*;|$)/i.test(contentType)) {
+      throw new Error('cognitum spaces: unexpected content type');
+    }
+    const raw = await readBoundedBody(res, this.cfg.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES);
+    let body: unknown;
+    try { body = JSON.parse(raw); } catch { throw new Error('cognitum spaces: malformed JSON'); }
+    return validateSpacesResult(body);
   }
 }
 
@@ -142,7 +201,85 @@ export interface SpacesBoundary {
 
 export interface SpacesListResult {
   data: CognitumSpaceTwin[];
-  boundary?: SpacesBoundary;
+  boundary: SpacesBoundary;
+}
+
+async function readBoundedBody(
+  response: Awaited<ReturnType<CognitumFetchLike>>,
+  maxBytes: number,
+): Promise<string> {
+  const declared = response.headers?.get('content-length');
+  if (declared !== undefined && declared !== null) {
+    const length = Number(declared);
+    if (!Number.isSafeInteger(length) || length < 0 || length > maxBytes) {
+      throw new Error('cognitum spaces: response too large');
+    }
+  }
+  if (response.body) {
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (!value) continue;
+      total += value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel?.().catch(() => undefined);
+        throw new Error('cognitum spaces: response too large');
+      }
+      chunks.push(value);
+    }
+    const joined = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) { joined.set(chunk, offset); offset += chunk.byteLength; }
+    return new TextDecoder('utf-8', { fatal: true }).decode(joined);
+  }
+  const raw = await response.text();
+  if (new TextEncoder().encode(raw).byteLength > maxBytes) throw new Error('cognitum spaces: response too large');
+  return raw;
+}
+
+function record(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function forbiddenRawField(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(forbiddenRawField);
+  if (!record(value)) return false;
+  return Object.entries(value).some(([key, child]) => {
+    const normalized = key.replace(/[^a-z0-9]/gi, '').toLowerCase();
+    return ['rawcsi', 'cir', 'rftensors', 'recordings', 'poseframes', 'vitalwaveforms', 'identityobservations'].includes(normalized)
+      || forbiddenRawField(child);
+  });
+}
+
+export function validateSpacesResult(value: unknown): SpacesListResult {
+  if (!record(value) || value.object !== 'list' || !Array.isArray(value.data) || value.data.length > MAX_SPACES) {
+    throw new Error('cognitum spaces: invalid list envelope');
+  }
+  const boundary = value.boundary;
+  if (!record(boundary) || boundary.authoritativeState !== 'HomeCore Edge'
+    || !Array.isArray(boundary.excluded)
+    || !boundary.excluded.every((item) => typeof item === 'string')
+    || REQUIRED_EXCLUSIONS.some((required) => !(boundary.excluded as string[]).includes(required))) {
+    throw new Error('cognitum spaces: invalid list envelope');
+  }
+  if (forbiddenRawField(value.data)) throw new Error('cognitum spaces: forbidden raw field');
+  const data = value.data.map((item): CognitumSpaceTwin => {
+    if (!record(item) || typeof item.id !== 'string' || !item.id || typeof item.tenantId !== 'string' || !item.tenantId
+      || typeof item.siteId !== 'string' || !item.siteId || typeof item.name !== 'string' || !item.name
+      || (item.privacy !== 'P2' && item.privacy !== 'P3') || !record(item.state) || item.state.classification !== 'P2'
+      || !record(item.provenance)) {
+      throw new Error('cognitum spaces: invalid space schema');
+    }
+    const confidence = item.state.confidence;
+    if (confidence !== null && (typeof confidence !== 'number' || !Number.isFinite(confidence) || confidence < 0 || confidence > 1)) {
+      throw new Error('cognitum spaces: invalid confidence');
+    }
+    return item as unknown as CognitumSpaceTwin;
+  });
+  return { data, boundary: boundary as unknown as SpacesBoundary };
 }
 
 /** Cognitum privacy (P2/P3, the cloud-bridged tiers) → radio-moe PrivacyClass. */
@@ -157,9 +294,11 @@ const toEpoch = (iso: string): number => {
 
 /**
  * Map a Cognitum Spaces Envelope to a radio-moe Observation so it flows through
- * `admitObservation` (ADR-402). Cognitum's `provenance`/`modelVersion` supply the
- * calibration identity the fail-closed admission requires; missing fields stay
- * empty so admission rejects them (unknown stays unknown).
+ * `admitObservation` (ADR-402). Only `modelVersion` supplies the calibration
+ * identity the fail-closed admission requires; provenance is retained as
+ * lineage, never reinterpreted as calibration. Missing fields stay empty so
+ * admission rejects them (unknown stays unknown). The `derived` lineage marker
+ * prevents a Spaces recollection from authorizing a workflow on a round trip.
  */
 export function spacesEnvelopeToObservation(env: CognitumSpacesEnvelope): Observation {
   return {
@@ -167,10 +306,18 @@ export function spacesEnvelopeToObservation(env: CognitumSpacesEnvelope): Observ
     location: env.siteId,
     kind: env.schema,
     value: env.payload,
-    confidence: typeof env.confidence === 'number' ? env.confidence : 0,
+    confidence: typeof env.confidence === 'number' ? env.confidence : Number.NaN,
     privacyClass: privacyOf(env.privacy),
-    calibrationVersion: env.modelVersion ?? env.provenance ?? '',
+    calibrationVersion: env.modelVersion ?? '',
     issuedAt: toEpoch(env.observedAt),
     expiresAt: toEpoch(env.expiresAt),
+    lineage: {
+      origin: 'cognitum-spaces',
+      tenantId: env.tenantId,
+      messageId: env.messageId,
+      sequence: env.sequence,
+      provenance: env.provenance,
+      derived: true,
+    },
   };
 }

--- a/packages/radio-moe/src/index.ts
+++ b/packages/radio-moe/src/index.ts
@@ -254,8 +254,9 @@ export {
 export { TlsPeerNode, tlsSendEnvelope, TlsConnection } from './tls-transport.js';
 
 // Cognitum Spaces adapter (ADR-402): connect the mesh to the DEPLOYED Cognitum
-// Spaces service (cog_-key/Bearer authed); map a Spaces Envelope → an Observation
-// so real spatial state flows through admitObservation.
+// Spaces gateway route (compatibility cog_ key or RuView PKCE `spaces:read`
+// access token); map a Spaces Envelope → a derived Observation so spatial state
+// flows through fail-closed admission without becoming independent authority.
 export {
   CognitumSpacesClient,
   spacesEnvelopeToObservation,
@@ -269,12 +270,12 @@ export {
   type CognitumSpacesEnvelope,
   type SpacesBoundary,
   type SpacesListResult,
-  type FetchLike as CognitumFetchLike,
+  type CognitumFetchLike,
 } from './cognitum-spaces.js';
 
-// Cognitum identity OAuth (ADR-093): a user completes the CLI session exchange and
-// the resulting Bearer token plugs into the Spaces/services clients — the mesh uses
-// Cognitum services under the user's own authenticated identity.
+// Cognitum identity CLI session exchange (ADR-093). Its `cognitum-cli` token is
+// for services that explicitly accept that audience; Spaces requires a separate
+// RuView PKCE token with `spaces:read`.
 export {
   CognitumIdentityClient,
   sessionAuth,

--- a/packages/radio-moe/src/observation.ts
+++ b/packages/radio-moe/src/observation.ts
@@ -38,6 +38,15 @@ export interface Observation {
   expiresAt: number;
   /** Optional sensor-health signal in [0, 1]; gated when a floor is set. */
   sensorHealth?: number;
+  /** Derivation identity. A cloud recollection is not independent evidence. */
+  lineage?: {
+    origin: 'cognitum-spaces';
+    tenantId: string;
+    messageId: string;
+    sequence: number;
+    provenance: string;
+    derived: true;
+  };
 }
 
 export type ObservationRejection =
@@ -49,6 +58,7 @@ export type ObservationRejection =
   | 'missing-calibration'
   | 'bad-window'
   | 'expired'
+  | 'invalid-lineage'
   | 'unhealthy-sensor';
 
 export interface ObservationAdmission {
@@ -92,6 +102,17 @@ export function admitObservation(obs: Observation, now: number, policy: Observat
     return { admissible: false, rejection: 'bad-window' };
   }
   if (obs.issuedAt > now + skew || now >= obs.expiresAt) return { admissible: false, rejection: 'expired' };
+  if (obs.lineage !== undefined && (
+    obs.lineage.origin !== 'cognitum-spaces' ||
+    obs.lineage.derived !== true ||
+    !obs.lineage.tenantId ||
+    !obs.lineage.messageId ||
+    !Number.isSafeInteger(obs.lineage.sequence) ||
+    obs.lineage.sequence < 0 ||
+    !obs.lineage.provenance
+  )) {
+    return { admissible: false, rejection: 'invalid-lineage' };
+  }
   if (policy.minSensorHealth !== undefined) {
     if (!finiteUnit(obs.sensorHealth) || obs.sensorHealth < policy.minSensorHealth) {
       return { admissible: false, rejection: 'unhealthy-sensor' };
@@ -115,6 +136,10 @@ export interface TierThresholds {
  * the `ActionGate`. This function does not grant authority; it classifies.
  */
 export function confidenceTier(obs: Observation, thresholds: TierThresholds = { low: 0.4, high: 0.75 }): ActionTier {
+  // A Spaces event is a recollection/derived belief, not a fresh independent
+  // observation. It may refresh the world model, but must never bootstrap its
+  // own corroboration or become workflow authority on a round trip.
+  if (obs.lineage?.derived === true) return 'update-world-model';
   if (obs.confidence >= thresholds.high) return 'authorized-workflow';
   if (obs.confidence >= thresholds.low) return 'request-more-sensing';
   return 'update-world-model';

--- a/packages/radio-moe/test/cognitum-identity.test.ts
+++ b/packages/radio-moe/test/cognitum-identity.test.ts
@@ -8,7 +8,6 @@ import {
   CognitumIdentityClient,
   sessionAuth,
   sessionActive,
-  CognitumSpacesClient,
   type CognitumFetchLike,
 } from '../src/index.js';
 
@@ -54,15 +53,9 @@ test('a session becomes a Cognitum auth that carries the Bearer token', async ()
   const auth = sessionAuth(session);
   assert.deepEqual(auth(), { authorization: 'Bearer acc_live_123' });
 
-  // and it drives the Spaces client end to end (injected fetch checks the header)
-  let sawAuth = '';
-  const spacesFetch: CognitumFetchLike = async (_u, init) => {
-    sawAuth = init.headers.authorization ?? '';
-    return { ok: true, status: 200, json: async () => ({ object: 'list', data: [] }), text: async () => '' };
-  };
-  const spaces = new CognitumSpacesClient({ auth, fetchImpl: spacesFetch });
-  await spaces.listSpaces();
-  assert.equal(sawAuth, 'Bearer acc_live_123');
+  // This token is client_id=cognitum-cli. It is intentionally NOT exercised
+  // against Spaces, whose resource policy requires aud/client_id=ruview and
+  // spaces:read from the PKCE activation flow.
 });
 
 test('sessionActive respects expiry', () => {

--- a/packages/radio-moe/test/cognitum-spaces.test.ts
+++ b/packages/radio-moe/test/cognitum-spaces.test.ts
@@ -1,6 +1,6 @@
 //! Cognitum Spaces adapter (ADR-402): envelope→observation mapping, auth headers,
 //! and listSpaces over an injected fetch. A LIVE test hits the deployed service
-//! only when COGNITUM_API_KEY is set (otherwise it skips).
+//! only when COGNITUM_SPACES_API is set (otherwise it skips).
 
 import test from 'node:test';
 import assert from 'node:assert/strict';
@@ -11,9 +11,15 @@ import {
   apiKeyAuth,
   bearerAuth,
   admitObservation,
+  confidenceTier,
   type CognitumSpacesEnvelope,
   type CognitumFetchLike,
 } from '../src/index.js';
+
+const REQUIRED_EXCLUSIONS_FOR_TEST = [
+  'raw_csi', 'cir', 'rf_tensors', 'recordings', 'pose_frames',
+  'vital_waveforms', 'identity_observations',
+];
 
 const ENVELOPE: CognitumSpacesEnvelope = {
   schema: 'motion-changed',
@@ -38,16 +44,21 @@ test('a Spaces envelope maps to an admissible Observation', () => {
   assert.equal(obs.confidence, 0.72);
   assert.equal(obs.privacyClass, 'restricted'); // P2
   assert.equal(obs.calibrationVersion, 'cal-2026-08');
+  assert.deepEqual(obs.lineage, {
+    origin: 'cognitum-spaces', tenantId: 't-1', messageId: 'm-1', sequence: 3,
+    provenance: 'edge-fusion', derived: true,
+  });
   // flows through the ADR-402 fail-closed admission at a time inside its window
   const now = Date.parse('2026-08-16T18:00:10.000Z');
   assert.equal(admitObservation(obs, now).admissible, true);
+  assert.equal(confidenceTier(obs), 'update-world-model');
 });
 
 test('privacy tiers and missing calibration are fail-closed downstream', () => {
   assert.equal(privacyOf('P3'), 'sensitive');
   assert.equal(privacyOf('P2'), 'restricted');
   const { modelVersion: _mv, ...noModel } = ENVELOPE;
-  const noCal = spacesEnvelopeToObservation({ ...noModel, provenance: '' });
+  const noCal = spacesEnvelopeToObservation({ ...noModel, provenance: 'not-a-calibration' });
   const now = Date.parse('2026-08-16T18:00:10.000Z');
   assert.equal(admitObservation(noCal, now).rejection, 'missing-calibration');
 });
@@ -64,24 +75,87 @@ test('listSpaces parses the real {object:list, data, boundary} shape + auth (inj
   const fake: CognitumFetchLike = async (url, init) => {
     seen.push({ url, headers: init.headers });
     return {
-      ok: true, status: 200, text: async () => '',
-      json: async () => ({
+      ok: true, status: 200,
+      text: async () => JSON.stringify({
         object: 'list',
-        data: [{ spaceId: 's1', connection: 'connected', twinStatus: 'live' }],
-        boundary: { authoritativeState: 'HomeCore Edge', excluded: ['raw_csi', 'pose_frames', 'vital_waveforms'] },
+        data: [{ id: 's1', tenantId: 't1', siteId: 'site1', name: 'Room', connection: 'connected', status: 'live', privacy: 'P2', state: { confidence: 0.8, occupancy: 1, classification: 'P2' }, provenance: {} }],
+        boundary: { authoritativeState: 'HomeCore Edge', excluded: ['raw_csi', 'cir', 'rf_tensors', 'recordings', 'pose_frames', 'vital_waveforms', 'identity_observations'] },
       }),
+      json: async () => ({}),
     };
   };
   const client = new CognitumSpacesClient({ baseUrl: 'https://gw.example', auth: apiKeyAuth(() => 'cog_xyz'), fetchImpl: fake });
   assert.equal(client.hasCredentials(), true);
   const result = await client.listSpacesResult();
   assert.equal(result.data.length, 1);
-  assert.equal(result.data[0]!.spaceId, 's1');
-  assert.deepEqual(result.boundary?.excluded, ['raw_csi', 'pose_frames', 'vital_waveforms']);
+  assert.equal(result.data[0]!.id, 's1');
+  assert.equal(result.boundary.excluded?.length, 7);
   assert.equal(seen[0]!.url, 'https://gw.example/v1/spaces');
   assert.equal(seen[0]!.headers['x-api-key'], 'cog_xyz');
   // legacy convenience: listSpaces() returns just the data array
   assert.equal((await client.listSpaces()).length, 1);
+});
+
+test('client rejects unsafe URLs, limits, and ambiguous credentials', async () => {
+  assert.throws(
+    () => new CognitumSpacesClient({ baseUrl: 'http://example.test', auth: () => ({}) }),
+    /HTTPS required/,
+  );
+  assert.throws(
+    () => new CognitumSpacesClient({ baseUrl: 'https://user:pass@example.test', auth: () => ({}) }),
+    /invalid base URL/,
+  );
+  assert.throws(
+    () => new CognitumSpacesClient({ auth: () => ({}), maxResponseBytes: 9 * 1024 * 1024 }),
+    /invalid response limit/,
+  );
+  const client = new CognitumSpacesClient({
+    auth: () => ({ 'x-api-key': 'cog_x', authorization: 'Bearer token', host: 'attacker.test' }),
+    fetchImpl: async () => { throw new Error('must not fetch'); },
+  });
+  assert.equal(client.hasCredentials(), false);
+  await assert.rejects(() => client.listSpaces(), /ambiguous credentials/);
+});
+
+test('strict validation rejects legacy casts, raw fields, and bad confidence', async () => {
+  const response = (body: unknown): CognitumFetchLike => async () => ({
+    ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body),
+  });
+  for (const body of [
+    [{ id: 'legacy-array' }],
+    { object: 'list', data: [], boundary: { authoritativeState: 'HomeCore Edge', excluded: ['raw_csi'] } },
+    { object: 'list', data: [{ id: 's', tenantId: 't', siteId: 'site', name: 'n', privacy: 'P2', state: { confidence: 2, classification: 'P2' }, provenance: {} }], boundary: { authoritativeState: 'HomeCore Edge', excluded: [...REQUIRED_EXCLUSIONS_FOR_TEST] } },
+    { object: 'list', data: [{ id: 's', tenantId: 't', siteId: 'site', name: 'n', privacy: 'P2', state: { confidence: 0.5, classification: 'P2', raw_csi: 'leak' }, provenance: {} }], boundary: { authoritativeState: 'HomeCore Edge', excluded: [...REQUIRED_EXCLUSIONS_FOR_TEST] } },
+  ]) {
+    const client = new CognitumSpacesClient({ auth: apiKeyAuth(() => 'cog_x'), fetchImpl: response(body) });
+    await assert.rejects(() => client.listSpaces(), /cognitum spaces:/);
+  }
+});
+
+test('response media type and byte limit fail closed', async () => {
+  const wrongType: CognitumFetchLike = async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: (name) => name === 'content-type' ? 'text/html' : null },
+    json: async () => ({}),
+    text: async () => '<html>not json</html>',
+  });
+  await assert.rejects(
+    () => new CognitumSpacesClient({ auth: apiKeyAuth(() => 'cog_x'), fetchImpl: wrongType }).listSpaces(),
+    /unexpected content type/,
+  );
+
+  const oversized: CognitumFetchLike = async () => ({
+    ok: true,
+    status: 200,
+    headers: { get: (name) => name === 'content-length' ? '4096' : 'application/json' },
+    json: async () => ({}),
+    text: async () => '{}',
+  });
+  await assert.rejects(
+    () => new CognitumSpacesClient({ auth: apiKeyAuth(() => 'cog_x'), fetchImpl: oversized, maxResponseBytes: 1024 }).listSpaces(),
+    /response too large/,
+  );
 });
 
 test('a non-ok response throws with the status', async () => {
@@ -91,9 +165,9 @@ test('a non-ok response throws with the status', async () => {
   await assert.rejects(() => client.listSpaces(), /HTTP 401/);
 });
 
-test('LIVE: GET /v1/spaces against the deployed service (skips without COGNITUM_API_KEY)', async (t) => {
-  const key = process.env.COGNITUM_API_KEY;
-  if (!key) { t.skip('COGNITUM_API_KEY not set — live Cognitum Spaces test skipped'); return; }
+test('LIVE: GET /v1/spaces against the deployed service (skips without COGNITUM_SPACES_API)', async (t) => {
+  const key = process.env.COGNITUM_SPACES_API;
+  if (!key) { t.skip('COGNITUM_SPACES_API not set — live Cognitum Spaces test skipped'); return; }
   const client = new CognitumSpacesClient({ auth: apiKeyAuth(() => key) });
   const result = await client.listSpacesResult(); // throws on non-2xx
   assert.ok(Array.isArray(result.data), 'live /v1/spaces returns a twin list');

--- a/packages/radio-moe/test/observation.test.ts
+++ b/packages/radio-moe/test/observation.test.ts
@@ -63,3 +63,28 @@ test('confidence maps to the ADR-402 action tier', () => {
   assert.equal(confidenceTier({ ...ok(), confidence: 0.5 }), 'request-more-sensing');
   assert.equal(confidenceTier({ ...ok(), confidence: 0.9 }), 'authorized-workflow');
 });
+
+test('Spaces-derived beliefs require valid lineage and cannot authorize a workflow', () => {
+  const derived: Observation = {
+    ...ok(),
+    confidence: 0.99,
+    lineage: {
+      origin: 'cognitum-spaces',
+      tenantId: 'tenant-1',
+      messageId: 'message-1',
+      sequence: 7,
+      provenance: 'edge-fusion',
+      derived: true,
+    },
+  };
+  assert.deepEqual(admitObservation(derived, NOW), { admissible: true });
+  assert.equal(confidenceTier(derived), 'update-world-model');
+  assert.equal(
+    admitObservation({ ...derived, lineage: { ...derived.lineage!, tenantId: '' } }, NOW).rejection,
+    'invalid-lineage',
+  );
+  assert.equal(
+    admitObservation({ ...derived, lineage: { ...derived.lineage!, sequence: -1 } }, NOW).rejection,
+    'invalid-lineage',
+  );
+});


### PR DESCRIPTION
## Outcome

Hardens ADR-402 and the radio-moe adapter so Cognitum Spaces remains untrusted P2/P3 evidence rather than privileged belief:

- distinguishes RuView OAuth access from CLI/device credentials;
- defaults API-key compatibility to `COGNITUM_SPACES_API`;
- rejects ambiguous credentials, unsafe URLs, redirects, non-JSON/oversized/deep payloads, malformed state, and recursive raw fields;
- preserves tenant/message/sequence provenance while holding derived observations to world-model update authority;
- requires the production HomeCore Edge boundary and exact P0/P1 exclusions;
- records verified live evidence and leaves write/retention gaps explicit.

Closes #1.

Related: ruvnet/RuView#1630, cognitum-one/api#187, cognitum-one/console#200.

## Validation

- `npm run typecheck`: passed.
- `npm test`: 143 passed, 2 existing optional tests skipped.
- Live Spaces adapter test using the externally supplied root `.env` credential: 1/1 passed without printing the token.
- Staged diff check and added-line secret scan: clean.