### PR TITLE
fix(ci): restore Rust quality gates

### DIFF
--- a/crates/service/examples/gen_promotion.rs
+++ b/crates/service/examples/gen_promotion.rs
@@ -14,7 +14,7 @@ use agl_types::{
 use antibody::Detector;
 use constitution::{Constitution, RoleKeys};
 use envelope::{
-    evaluate_and_sign, CandidateManifest, InvariantProof, ProofArtifact, PromotionEnvelope,
+    evaluate_and_sign, CandidateManifest, InvariantProof, PromotionEnvelope, ProofArtifact,
 };
 use evaluator::Corpus;
 use promotion::CanaryController;
@@ -101,16 +101,39 @@ fn main() {
     let cand_hash = manifest.candidate_hash();
     let parent_hash = content_hash(&p.hash);
     let r1 = evaluate_and_sign(
-        &j1, &cand_hash, &parent_hash, &candidate, &parent_detector, &cp, "corpus-v1", "eval-1",
-        1.5, NOW,
+        &j1,
+        &cand_hash,
+        &parent_hash,
+        &candidate,
+        &parent_detector,
+        &cp,
+        "corpus-v1",
+        "eval-1",
+        1.5,
+        NOW,
     );
     let r2 = evaluate_and_sign(
-        &j2, &cand_hash, &parent_hash, &candidate, &parent_detector, &cp, "corpus-v1", "eval-1",
-        1.6, NOW,
+        &j2,
+        &cand_hash,
+        &parent_hash,
+        &candidate,
+        &parent_detector,
+        &cp,
+        "corpus-v1",
+        "eval-1",
+        1.6,
+        NOW,
     );
     let receipts = vec![r1, r2];
-    let envelope =
-        PromotionEnvelope::signed(&ctrl, &c.hash(), &cand_hash, &receipts, "nonce-e2e", NOW, 600);
+    let envelope = PromotionEnvelope::signed(
+        &ctrl,
+        &c.hash(),
+        &cand_hash,
+        &receipts,
+        "nonce-e2e",
+        NOW,
+        600,
+    );
 
     // Drive a canary to 100%-healthy so `promote()` will finalize it.
     let mut controller = CanaryController::new(&cand_hash, &p.hash, HardGates::default(), 1);

--- a/crates/service/src/main.rs
+++ b/crates/service/src/main.rs
@@ -17,15 +17,15 @@
 //! always yield the same verdict — independently re-runnable per ADR-392 §3.4.
 
 use agl_types::{FitnessVector, Genome, HardGates, Mutation};
+use antibody::Detector;
 use axum::{
     routing::{get, post},
     Json, Router,
 };
-use antibody::Detector;
 use constitution::Constitution;
 use envelope::{
     evaluate_and_sign, verify_promotion_artifact, CandidateManifest, EvaluationReceipt,
-    ProofArtifact, PromotionEnvelope,
+    PromotionEnvelope, ProofArtifact,
 };
 use evaluator::Corpus;
 use promotion::{CanaryController, CanaryState, Decision};
@@ -91,7 +91,7 @@ async fn agl_admit(Json(req): Json<AdmitRequest>) -> Json<AdmitResponse> {
             // machine code (the variant name) + a full human reason from it.
             let full = format!("{e:?}");
             let code = full
-                .split(|c: char| c == ' ' || c == '(' || c == '{')
+                .split([' ', '(', '{'])
                 .next()
                 .unwrap_or("Error")
                 .to_string();
@@ -308,7 +308,9 @@ fn judge_authorities() -> Vec<SigningAuthority> {
             dev_judges()
         }
         Err(_) => {
-            tracing::warn!("AUTOGENOUS_JUDGE_SEEDS unset; using DEV judge keys (pin real keys in prod)");
+            tracing::warn!(
+                "AUTOGENOUS_JUDGE_SEEDS unset; using DEV judge keys (pin real keys in prod)"
+            );
             dev_judges()
         }
     }
@@ -322,7 +324,10 @@ fn dev_judges() -> Vec<SigningAuthority> {
 }
 
 fn controller_authority() -> SigningAuthority {
-    match std::env::var("AUTOGENOUS_CONTROLLER_SEED").ok().and_then(|s| seed_from_hex(&s)) {
+    match std::env::var("AUTOGENOUS_CONTROLLER_SEED")
+        .ok()
+        .and_then(|s| seed_from_hex(&s))
+    {
         Some(seed) => SigningAuthority::from_seed("controller", seed),
         None => SigningAuthority::from_seed("controller", [3u8; 32]),
     }
@@ -389,14 +394,17 @@ async fn judges_evaluate(Json(req): Json<EvaluateRequest>) -> Json<EvaluateRespo
     // Refuse to originate evidence under a constitution that doesn't pin us —
     // the key policy is constitutionally governed, not self-asserted.
     let pinned = &req.constitution.pinned_keys;
-    if !judges.iter().all(|j| pinned.judges.contains(&j.public_hex()))
+    if !judges
+        .iter()
+        .all(|j| pinned.judges.contains(&j.public_hex()))
         || !pinned.controllers.contains(&controller.public_hex())
     {
         return Json(EvaluateResponse {
             receipts: vec![],
             envelope: None,
             error: Some(
-                "this service's judge/controller keys are not pinned in the submitted constitution".into(),
+                "this service's judge/controller keys are not pinned in the submitted constitution"
+                    .into(),
             ),
         });
     }

--- a/crates/service/tests/promote_e2e.rs
+++ b/crates/service/tests/promote_e2e.rs
@@ -13,7 +13,7 @@ use antibody::Detector;
 use constitution::{Constitution, RoleKeys};
 use envelope::{
     evaluate_and_sign, verify_promotion_artifact, CandidateManifest, EvaluationReceipt,
-    InvariantProof, ProofArtifact, PromotionEnvelope,
+    InvariantProof, PromotionEnvelope, ProofArtifact,
 };
 use evaluator::Corpus;
 use promotion::{CanaryController, CanaryState};
@@ -104,16 +104,39 @@ fn bundle() -> (
     let parent_hash = content_hash(&p.hash);
     let receipts = vec![
         evaluate_and_sign(
-            &j1, &cand_hash, &parent_hash, &candidate, &parent_detector, &cp, "corpus-v1",
-            "eval-1", 1.5, NOW,
+            &j1,
+            &cand_hash,
+            &parent_hash,
+            &candidate,
+            &parent_detector,
+            &cp,
+            "corpus-v1",
+            "eval-1",
+            1.5,
+            NOW,
         ),
         evaluate_and_sign(
-            &j2, &cand_hash, &parent_hash, &candidate, &parent_detector, &cp, "corpus-v1",
-            "eval-1", 1.6, NOW,
+            &j2,
+            &cand_hash,
+            &parent_hash,
+            &candidate,
+            &parent_detector,
+            &cp,
+            "corpus-v1",
+            "eval-1",
+            1.6,
+            NOW,
         ),
     ];
-    let envelope =
-        PromotionEnvelope::signed(&ctrl, &c.hash(), &cand_hash, &receipts, "nonce-e2e", NOW, 600);
+    let envelope = PromotionEnvelope::signed(
+        &ctrl,
+        &c.hash(),
+        &cand_hash,
+        &receipts,
+        "nonce-e2e",
+        NOW,
+        600,
+    );
     let mut controller = CanaryController::new(&cand_hash, &p.hash, HardGates::default(), 1);
     let good = FitnessVector {
         task_quality: 1.0,
@@ -128,7 +151,15 @@ fn bundle() -> (
     for _ in 0..4 {
         controller.observe(&good);
     }
-    (c, p, manifest, receipts, envelope, vec![artifact], controller)
+    (
+        c,
+        p,
+        manifest,
+        receipts,
+        envelope,
+        vec![artifact],
+        controller,
+    )
 }
 
 #[test]
@@ -136,7 +167,9 @@ fn a_valid_signed_bundle_promotes_the_canary() {
     let (c, p, m, r, e, arts, mut controller) = bundle();
     let vp = verify_promotion_artifact(&c, &p, &m, &r, &e, &arts, NOW + 1)
         .expect("clean bundle must verify");
-    controller.promote(&vp, NOW + 1).expect("promote must succeed");
+    controller
+        .promote(&vp, NOW + 1)
+        .expect("promote must succeed");
     assert!(matches!(controller.state, CanaryState::Promoted { .. }));
 }
 


### PR DESCRIPTION
## Summary

- apply the repository's canonical `cargo fmt --all` output to the three drifted service files
- replace one manual character-comparison closure rejected by current stable Clippy with its equivalent pattern array
- restore the main CI path so downstream feature PRs reach clippy and workspace tests

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `git diff --check`

Closes #3