### PR TITLE
feat(radio-moe): integrate versioned Cognitum Spaces

### DIFF
--- a/.github/workflows/radio-moe-npm-release.yml
+++ b/.github/workflows/radio-moe-npm-release.yml
@@ -1,0 +1,64 @@
+name: radio-moe npm release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dist_tag:
+        description: npm dist-tag
+        required: false
+        default: latest
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: radio-moe-npm-release
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment: npm-release
+    defaults:
+      run:
+        working-directory: packages/radio-moe
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+          ref: refs/heads/main
+
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '24'
+          registry-url: https://registry.npmjs.org
+
+      - name: Install and verify
+        run: |
+          npm ci --ignore-scripts
+          npm run typecheck
+          npm test
+          npm audit --audit-level=high
+
+      - name: Pack and smoke the exact artifact
+        run: |
+          set -euo pipefail
+          TGZ="$PWD/$(npm pack --silent 2>/dev/null | tail -1)"
+          SHA512="$(sha512sum "$TGZ" | cut -d' ' -f1)"
+          printf 'PACKAGE_TARBALL=%s\nPACKAGE_TARBALL_SHA512=%s\n' "$TGZ" "$SHA512" >> "$GITHUB_ENV"
+          SMOKE="$(mktemp -d)"
+          cd "$SMOKE"
+          npm init -y >/dev/null
+          npm install --ignore-scripts --no-fund --no-audit "$TGZ"
+          node --input-type=module -e "const m = await import('radio-moe'); if (typeof m.CognitumSpacesClient !== 'function' || typeof m.spatialResourceToObservation !== 'function') process.exit(1)"
+
+      - name: Publish with provenance
+        run: |
+          printf '%s  %s\n' "$PACKAGE_TARBALL_SHA512" "$PACKAGE_TARBALL" | sha512sum --check -
+          npm publish "$PACKAGE_TARBALL" --provenance --access public --tag "$NPM_DIST_TAG"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_DIST_TAG: ${{ inputs.dist_tag }}

--- a/docs/adr/ADR-402-ruview-cognitum-spaces-spatial-intelligence.md
+++ b/docs/adr/ADR-402-ruview-cognitum-spaces-spatial-intelligence.md
@@ -1,8 +1,9 @@
 # ADR-402 — RuView + Cognitum Spaces: the spatial-intelligence layer
 
-- Status: **Accepted** (the read-side adapter and fail-closed seam are
-  implemented in `radio-moe`; write-side synchronization and the 30-day
-  operational acceptance test remain separately gated rollout work)
+- Status: **Accepted** (legacy and versioned read-side adapters plus the
+  fail-closed seam are implemented in the `radio-moe` 0.3.0 release candidate;
+  versioned API deployment, npm publication, write-side synchronization, and
+  the 30-day operational acceptance test remain separately gated rollout work)
 - Date: 2026-08-16
 - Related: ADR-401 (Perpetual Intelligence Machine — this is capability 8
   expanded), ADR-397 (streaming mixture), ADR-399 (midstream, RVM/RVF),
@@ -47,6 +48,27 @@ Spaces-derived state is explicitly `derived` and is capped at
 from returning as apparently independent workflow authority. Missing
 confidence remains unknown (`NaN`) and missing `modelVersion` remains missing
 calibration; provenance is never used as a calibration substitute.
+
+**Update (2026-08-19) — the full versioned read contract is implemented and
+locally validated.** Cognitum API ADR-101 defines read-only pages for `sites`,
+`buildings`, `floors`, `spaces`, `zones`, anonymous `entities`, semantic
+`events`, and `alerts`. `CognitumSpacesClient.listSpatial` binds the collection
+to a fixed path, accepts a 1–100 limit and opaque bounded cursor, requires a UUID
+workspace for compatibility API keys, and relies on the signed workspace for
+RuView OAuth. It validates schema `1.0`, hierarchy parents, entity anonymity,
+event/alert fields, confidence, time, IDs, page cursors, the HomeCore boundary,
+and recursive byte/depth/node/array/object/string/raw-field limits.
+
+`spatialResourceToObservation` preserves tenant/message/sequence lineage and
+marks the result derived before it reaches `admitObservation`. It uses only
+explicit provenance source/model/digest fields. Missing calibration, source,
+confidence, or semantic expiry remains missing and therefore fails closed. A
+retention deadline is never reinterpreted as observation freshness. The client
+still exposes no write, policy approval, command, or actuator method.
+
+The locally green versioned adapter is not yet a production claim. Production
+continues to mean the legacy `/v1/spaces` evidence below until the Cognitum API
+deployment workflow, index/TTL readiness, and OAuth readback complete.
 
 ## Functional architecture
 
@@ -203,7 +225,14 @@ the same false-consensus guard ADR-401 makes constitutional, applied to sensors.
    helper remains available only to services accepting the `cognitum-cli`
    audience. Spaces requires RuView PKCE + `spaces:read`; compatibility API keys
    remain read from a Spaces-specific environment variable.
-4. **Remaining ADR-402 loop items:** the timed failover bench (**done**, shared
+4. **Versioned spatial read:** the hierarchy/event/alert adapter, strict page
+   validator, and derived-observation mapper are **built and locally tested**.
+   Production remains gated on Cognitum API ADR-101 deployment/readback.
+5. **Release authority:** `radio-moe` 0.3.0 may publish only from the main-only
+   `radio-moe npm release` workflow. It rebuilds, typechecks, tests, audits,
+   packs and smoke-imports the exact tarball, verifies its digest, and publishes
+   with npm provenance. A local `npm publish` is not release evidence.
+6. **Remaining ADR-402 loop items:** the timed failover bench (**done**, shared
    with ADR-401), the fusion false-alert bench (**done** —
    `bench-false-alert.ts`), the sovereign-peer local-data boundary (open under
    ADR-401 capability 6), and the explicitly authorized write-side exchange.

--- a/packages/radio-moe/README.md
+++ b/packages/radio-moe/README.md
@@ -59,6 +59,8 @@ console.log(res.metrics);  // routingMs, timeToFirstFrameMs, dataFrames, rejecte
 
 New here? Read the **[User Guide](docs/USER-GUIDE.md)** (task-oriented, five walkthroughs)
 and the **[API / SDK Reference](docs/API.md)** (every public export, grouped by layer).
+For RuView/Cognitum integration, use the
+**[Cognitum Spaces guide](docs/COGNITUM-SPACES.md)**.
 
 ## What's in the box
 
@@ -73,7 +75,7 @@ and the **[API / SDK Reference](docs/API.md)** (every public export, grouped by 
 | **Real backends** | `openRouterExpert`, `geminiExpert`, `CommandStreamingExpert` (`claude`/`codex`), `harnessPodExperts` | Run the mesh against OpenRouter / Gemini / local `claude -p` / `codex exec` / create-agent-harness pods. |
 | **Governed evolution (ADR-400/401)** | `evolveMesh`, `promotable`, `promoteAuthorized`, `verifyLedger`, `CEILINGS` | Flywheel over the *evolvable* params only, inside frozen ceilings, ed25519-signed receipts; promotion gated by the one predicate `Better ∧ Safe ∧ Authorized ∧ Reversible`. |
 | **Reputation market (ADR-401 cap 9)** | `signCapabilityClaim`, `mintPerformanceRecord`, `reputation`, `selectionWeight` | Peers advertise capabilities and earn reputation only from externally-verified contribution (tied to `admitDurableWrite`); the `w=q·t·r/(c·l)` selection weight is a labeled *unvalidated* hypothesis. |
-| **Cognitum integration (ADR-402/093)** | `CognitumSpacesClient`, `spacesEnvelopeToObservation`, `CognitumIdentityClient`, `sessionAuth` | Connect the mesh to the DEPLOYED Cognitum Spaces service (live `GET /v1/spaces`) under a user's Cognitum OAuth session (identity CLI exchange → Bearer); map Spaces envelopes → Observations. |
+| **Cognitum integration (ADR-402/093)** | `CognitumSpacesClient`, `spacesEnvelopeToObservation`, `spatialResourceToObservation`, `CognitumIdentityClient`, `sessionAuth` | Read the deployed legacy Space twins and the versioned hierarchy/events/alerts release candidate under API-key or RuView OAuth authority; validate the semantic-only boundary and map records into fail-closed derived observations. |
 
 ## Architecture
 

--- a/packages/radio-moe/docs/COGNITUM-SPACES.md
+++ b/packages/radio-moe/docs/COGNITUM-SPACES.md
@@ -1,0 +1,158 @@
+# Cognitum Spaces user guide
+
+Cognitum Spaces is the governed spatial world model used by RuView and
+`radio-moe`. RuView keeps raw RF/CSI and perception processing local. Cognitum
+receives only permitted P2/P3 semantic state: sites, buildings, floors,
+rooms/spaces, zones, anonymous entities, semantic events, and alerts.
+
+The integration is read-only. Reading a Space can inform an observation or
+recommendation, but it cannot publish state, approve a policy, command a device,
+or actuate anything.
+
+## Capabilities
+
+| Capability | Legacy `/v1/spaces` | Versioned `/v1/spatial/*` | `radio-moe` behavior |
+|---|---|---|---|
+| Current room/space twins | Yes | Yes, as `spaces` | Strictly validates P2/P3 and the local-edge boundary |
+| Sites, buildings, floors, zones | No | Yes | Paged, typed, read-only |
+| Anonymous entities | No | Yes | Rejects person/track data without `identityMode=anonymous` |
+| Semantic events and alerts | No | Yes | Preserves message/sequence lineage |
+| Raw CSI, CIR, RF tensors, recordings, pose, vitals, identity observations | No | No | Rejects forbidden aliases at every nesting depth |
+| OAuth activation | `spaces:read` | `spaces:read` | Bearer token supplied by the caller |
+| API-key compatibility | Yes | Yes, with an explicit workspace UUID | Reads `COGNITUM_SPACES_API` only at call time |
+| Writes or actuator commands | Not exposed | Not exposed | No client method exists |
+
+## Install
+
+```bash
+npm install radio-moe
+```
+
+## Authenticate
+
+For an end user, activate RuView with Cognitum OAuth:
+
+```bash
+wifi-densepose login --spaces
+wifi-densepose whoami
+```
+
+The public client uses Authorization Code + PKCE and requests
+`sensing:read spaces:read`. Pass the resulting access token to your process by
+your normal secret channel; do not put it in source, logs, URLs, or a gist.
+
+For service compatibility, set an API key without printing it:
+
+```bash
+export COGNITUM_SPACES_API='cog_...'
+```
+
+OAuth is preferred for end-user activation. API-key versioned reads require an
+explicit workspace UUID because an API key does not carry the signed workspace
+claim that an OAuth access token carries.
+
+## Read current Space twins
+
+```ts
+import {
+  CognitumSpacesClient,
+  envApiKeyAuth,
+} from 'radio-moe';
+
+const spaces = new CognitumSpacesClient({ auth: envApiKeyAuth() });
+const result = await spaces.listSpacesResult();
+
+console.log(result.data.map(({ id, name, status }) => ({ id, name, status })));
+console.log(result.boundary.excluded); // raw sensing that remains local
+```
+
+Credentials are resolved when the request is made, so key rotation does not
+require constructing a new client. The client requires HTTPS except for an
+explicit loopback test origin, rejects redirects and ambiguous credentials,
+bounds response time/size/shape, and validates the reported local-edge privacy
+boundary.
+
+## Page versioned resources
+
+```ts
+import {
+  CognitumSpacesClient,
+  bearerAuth,
+  spatialResourceToObservation,
+} from 'radio-moe';
+
+const client = new CognitumSpacesClient({
+  auth: bearerAuth(() => process.env.COGNITUM_OAUTH_ACCESS_TOKEN),
+});
+
+let cursor: string | undefined;
+do {
+  const page = await client.listSpatial('events', { limit: 50, cursor });
+  for (const resource of page.data) {
+    const observation = spatialResourceToObservation(resource);
+    // Pass through admitObservation before using it as a fact.
+    console.log(observation.kind, observation.lineage);
+  }
+  cursor = page.nextCursor ?? undefined;
+} while (cursor);
+```
+
+With API-key auth, add `workspaceId`:
+
+```ts
+await client.listSpatial('alerts', {
+  workspaceId: '00000000-0000-4000-8000-000000000000',
+  limit: 25,
+});
+```
+
+Cursors are opaque and kind-bound. Do not edit or reuse a cursor for another
+collection.
+
+## Observation admission
+
+`spatialResourceToObservation` marks every cloud-derived record with
+`lineage.derived=true`. It carries tenant, message, sequence, and provenance
+references forward without turning cloud recollection into new sensing
+authority. Missing calibration identity, confidence, provenance, or expiry
+remains missing; `admitObservation` then rejects the record instead of
+inventing trust.
+
+This is the expected flow:
+
+```text
+local RuView sensing
+  -> bounded P2/P3 semantic event
+  -> Cognitum tenant/workspace history
+  -> read-only radio-moe observation
+  -> fail-closed observation admission
+  -> observe or recommend
+  -> separate policy approval for any consequential execution
+```
+
+## Troubleshooting
+
+- `HTTP 401`: the credential is absent, expired, malformed, or not a supported
+  API key/RuView access token.
+- `HTTP 403`: OAuth is missing `spaces:read`, the client/audience is wrong, or
+  the workspace binding is not authorized.
+- `API-key spatial reads require workspace id`: supply the tenant's workspace
+  UUID; do not guess it.
+- `forbidden raw field`: the server response contained a field that violates
+  the semantic-only cloud boundary. Treat this as a privacy failure.
+- `invalid spatial resource`: hierarchy, UUID, timestamp, entity privacy,
+  confidence, or schema-version validation failed. Do not coerce the record.
+- An empty list is valid and means no authorized state is present; it is not
+  proof that a site is empty.
+
+## Security boundary
+
+- Keep tokens and keys out of command history, source, screenshots, and logs.
+- Do not interpret OAuth consent as write, approval, or actuator authority.
+- Do not forward raw sensing into `attributes` or `provenance`.
+- Treat `observedAt` and `expiresAt` as the freshness authority; retrieval
+  time does not refresh an observation.
+- Preserve tenant/workspace separation when caching or embedding history.
+
+The design of record is
+[ADR-402](../../../docs/adr/ADR-402-ruview-cognitum-spaces-spatial-intelligence.md).

--- a/packages/radio-moe/package-lock.json
+++ b/packages/radio-moe/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "radio-moe",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "radio-moe",
-      "version": "0.2.0",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@metaharness/radio": "^0.1.0"

--- a/packages/radio-moe/package.json
+++ b/packages/radio-moe/package.json
@@ -1,6 +1,6 @@
 {
   "name": "radio-moe",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "description": "Radio real-time streaming peer expert mesh — bounded, signed, constitution-pinned distributed MoE. @metaharness/radio is the metadata-only control plane; a signed direct peer transport carries expert streams. True logit mixing where tokenizers match; safe text-primary racing otherwise.",
   "type": "module",
   "license": "MIT",

--- a/packages/radio-moe/src/cognitum-spaces.ts
+++ b/packages/radio-moe/src/cognitum-spaces.ts
@@ -1,10 +1,11 @@
-//! Cognitum Spaces adapter — connect the mesh to the DEPLOYED Cognitum Spaces
-//! service (ADR-402's world-model layer, made real).
+//! Cognitum Spaces adapter — connect the mesh to Cognitum Spaces
+//! (ADR-402's world-model layer).
 //!
 //! ADR-402 specified Cognitum Spaces as the external spatial world-model the mesh
-//! plugs into. It is deployed behind the Cognitum API gateway at
-//! `GET /v1/spaces`. This adapter reads spatial twin
-//! state over that REST surface and maps a Cognitum Spaces **Envelope** to a
+//! plugs into. The legacy `GET /v1/spaces` route is deployed behind the
+//! Cognitum API gateway; the same adapter supports the accepted versioned
+//! `GET /v1/spatial/{kind}` family when enabled. It reads spatial twin state
+//! over that REST surface and maps a Cognitum Spaces **Envelope** to a
 //! radio-moe **Observation**, so real spatial state flows through `admitObservation`
 //! (the same fail-closed admission — no fact without confidence/privacy/expiry).
 //!
@@ -24,7 +25,8 @@ export type CognitumAuth = () => Record<string, string>;
 export function apiKeyAuth(getKey: () => string | undefined): CognitumAuth {
   return () => {
     const k = getKey();
-    return k?.startsWith('cog_') ? { 'x-api-key': k } : {};
+    return typeof k === 'string' && k.startsWith('cog_') && k.length > 4 && k.length <= 512
+      && !/[\s\u0000-\u001f\u007f]/u.test(k) ? { 'x-api-key': k } : {};
   };
 }
 
@@ -32,7 +34,8 @@ export function apiKeyAuth(getKey: () => string | undefined): CognitumAuth {
 export function bearerAuth(getToken: () => string | undefined): CognitumAuth {
   return () => {
     const t = getToken();
-    return t ? { authorization: `Bearer ${t}` } : {};
+    return typeof t === 'string' && t.length > 0 && t.length <= 8192
+      && !/[\s\u0000-\u001f\u007f]/u.test(t) ? { authorization: `Bearer ${t}` } : {};
   };
 }
 
@@ -63,12 +66,17 @@ export interface CognitumSpacesConfig {
   maxResponseBytes?: number;
 }
 
-/** The deployed Cognitum Spaces gateway route (verified live with a `cog_` key). */
+/** The Cognitum Spaces gateway origin; the legacy route is verified live. */
 const DEFAULT_BASE_URL = 'https://api.cognitum.one';
 const DEFAULT_TIMEOUT_MS = 10_000;
 const DEFAULT_MAX_RESPONSE_BYTES = 1024 * 1024;
 const MAX_CONFIGURED_RESPONSE_BYTES = 8 * 1024 * 1024;
 const MAX_SPACES = 100;
+const MAX_JSON_DEPTH = 16;
+const MAX_JSON_NODES = 10_000;
+const MAX_ARRAY_ITEMS = 1_000;
+const MAX_OBJECT_KEYS = 128;
+const MAX_STRING_BYTES = 4_096;
 const REQUIRED_EXCLUSIONS = [
   'raw_csi', 'cir', 'rf_tensors', 'recordings', 'pose_frames',
   'vital_waveforms', 'identity_observations',
@@ -90,6 +98,60 @@ export interface CognitumSpaceTwin {
   state: { confidence: number | null; occupancy: number | null; classification: 'P2'; [k: string]: unknown };
   provenance: Record<string, unknown>;
   [k: string]: unknown;
+}
+
+/** Versioned spatial collections from Cognitum API ADR-101. */
+export const SPATIAL_KINDS = [
+  'sites', 'buildings', 'floors', 'spaces', 'zones', 'entities', 'events', 'alerts',
+] as const;
+export type SpatialKind = typeof SPATIAL_KINDS[number];
+
+/** One strictly validated P2/P3 resource from `/v1/spatial/{kind}`. */
+export interface CognitumSpatialResource {
+  id: string;
+  tenantId: string;
+  workspaceId: string;
+  kind: SpatialKind;
+  schemaVersion: '1.0';
+  privacy: 'P2' | 'P3';
+  messageId: string;
+  eventSequence: number;
+  version: number;
+  siteId?: string | null;
+  buildingId?: string | null;
+  floorId?: string | null;
+  spaceId?: string | null;
+  zoneId?: string | null;
+  name?: string | null;
+  entityType?: 'sensor' | 'person' | 'object' | 'track' | null;
+  identityMode?: 'anonymous' | null;
+  eventType?: string | null;
+  alertType?: string | null;
+  severity?: 'info' | 'warning' | 'critical' | null;
+  status?: 'open' | 'acknowledged' | 'resolved' | null;
+  observedAt: string;
+  expiresAt?: string | null;
+  retentionExpiresAt?: string | null;
+  confidence?: number | null;
+  attributes: Record<string, unknown>;
+  provenance: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+export interface SpatialPageRequest {
+  limit?: number;
+  cursor?: string;
+  /** Required for API-key compatibility; OAuth derives workspace from the token. */
+  workspaceId?: string;
+}
+
+export interface SpatialListResult {
+  object: 'list';
+  kind: SpatialKind;
+  schemaVersion: '1.0';
+  data: CognitumSpatialResource[];
+  nextCursor: string | null;
+  boundary: SpacesBoundary;
 }
 
 /** A Cognitum Spaces MQTT-fabric Envelope (asyncapi/cognitum-spaces.yaml). */
@@ -152,22 +214,13 @@ export class CognitumSpacesClient {
     return {};
   }
 
-  /** GET /v1/spaces — the caller's authorized spatial twins. Returns just the
-   *  twin list; use {@link listSpacesResult} for the privacy boundary too. */
-  async listSpaces(): Promise<CognitumSpaceTwin[]> {
-    return (await this.listSpacesResult()).data;
-  }
-
-  /** GET /v1/spaces — the full Stripe-style list result, INCLUDING the service's
-   *  `boundary` (what raw sensing it deliberately excludes from the cloud — the
-   *  ADR-402 "raw sensing stays local" enforcement, verifiable at the edge). */
-  async listSpacesResult(): Promise<SpacesListResult> {
+  private async getJson(path: string): Promise<unknown> {
     const fetchImpl = this.cfg.fetchImpl ?? (globalThis.fetch as unknown as CognitumFetchLike);
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), this.cfg.timeoutMs ?? DEFAULT_TIMEOUT_MS);
     let res;
     try {
-      res = await fetchImpl(`${this.baseUrl}/v1/spaces`, {
+      res = await fetchImpl(`${this.baseUrl}${path}`, {
         method: 'GET',
         headers: { accept: 'application/json', ...this.authHeaders() },
         signal: controller.signal,
@@ -185,9 +238,47 @@ export class CognitumSpacesClient {
       throw new Error('cognitum spaces: unexpected content type');
     }
     const raw = await readBoundedBody(res, this.cfg.maxResponseBytes ?? DEFAULT_MAX_RESPONSE_BYTES);
-    let body: unknown;
-    try { body = JSON.parse(raw); } catch { throw new Error('cognitum spaces: malformed JSON'); }
-    return validateSpacesResult(body);
+    try { return JSON.parse(raw); } catch { throw new Error('cognitum spaces: malformed JSON'); }
+  }
+
+  /** GET /v1/spaces — the caller's authorized spatial twins. Returns just the
+   *  twin list; use {@link listSpacesResult} for the privacy boundary too. */
+  async listSpaces(): Promise<CognitumSpaceTwin[]> {
+    return (await this.listSpacesResult()).data;
+  }
+
+  /** GET /v1/spaces — the full Stripe-style list result, INCLUDING the service's
+   *  `boundary` (what raw sensing it deliberately excludes from the cloud — the
+   *  ADR-402 "raw sensing stays local" enforcement, verifiable at the edge). */
+  async listSpacesResult(): Promise<SpacesListResult> {
+    return validateSpacesResult(await this.getJson('/v1/spaces'));
+  }
+
+  /** Page one exact versioned hierarchy/event/alert collection. Read-only. */
+  async listSpatial(kind: SpatialKind, page: SpatialPageRequest = {}): Promise<SpatialListResult> {
+    if (!SPATIAL_KINDS.includes(kind)) throw new Error('cognitum spaces: invalid spatial kind');
+    const limit = page.limit ?? 50;
+    if (!Number.isSafeInteger(limit) || limit < 1 || limit > 100) {
+      throw new Error('cognitum spaces: invalid page limit');
+    }
+    if (page.cursor !== undefined
+      && (!page.cursor || page.cursor.length > 512 || /[\u0000-\u001f\u007f]/u.test(page.cursor))) {
+      throw new Error('cognitum spaces: invalid page cursor');
+    }
+    if (page.workspaceId !== undefined && !UUID_RE.test(page.workspaceId)) {
+      throw new Error('cognitum spaces: invalid workspace id');
+    }
+    const auth = this.authHeaders();
+    if (auth['x-api-key'] !== undefined && page.workspaceId === undefined) {
+      throw new Error('cognitum spaces: API-key spatial reads require workspace id');
+    }
+    const query = new URLSearchParams({ limit: String(limit) });
+    if (page.cursor) query.set('cursor', page.cursor);
+    if (page.workspaceId) query.set('workspaceId', page.workspaceId);
+    return validateSpatialResult(
+      await this.getJson(`/v1/spatial/${kind}?${query.toString()}`),
+      kind,
+    );
   }
 }
 
@@ -244,17 +335,56 @@ function record(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
+const ID_RE = /^[A-Za-z0-9][A-Za-z0-9_.:-]{0,119}$/;
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+const FORBIDDEN_FIELDS = new Set([
+  'rawcsi', 'csi', 'channelstateinformation', 'cir', 'rawcir', 'channelimpulseresponse',
+  'rftensor', 'rftensors', 'packetcapture', 'packetcaptures', 'pcap', 'recording', 'recordings',
+  'audiorecording', 'videorecording', 'poseframe', 'poseframes', 'skeleton',
+  'keypoints', 'vitalwaveform', 'vitalwaveforms', 'heartratewaveform',
+  'identityobservation', 'identityobservations', 'biometric', 'biometrics', 'face',
+  'faces', 'faceembedding',
+]);
+
+function assertBoundedSemantic(value: unknown): void {
+  let nodes = 0;
+  const visit = (current: unknown, depth: number): void => {
+    nodes += 1;
+    if (nodes > MAX_JSON_NODES || depth > MAX_JSON_DEPTH) throw new Error('cognitum spaces: response structure exceeds bound');
+    if (typeof current === 'string') {
+      if (new TextEncoder().encode(current).byteLength > MAX_STRING_BYTES) throw new Error('cognitum spaces: response string exceeds bound');
+      return;
+    }
+    if (Array.isArray(current)) {
+      if (current.length > MAX_ARRAY_ITEMS) throw new Error('cognitum spaces: response array exceeds bound');
+      for (const item of current) visit(item, depth + 1);
+      return;
+    }
+    if (!record(current)) return;
+    const entries = Object.entries(current);
+    if (entries.length > MAX_OBJECT_KEYS) throw new Error('cognitum spaces: response object exceeds bound');
+    for (const [key, child] of entries) {
+      if (new TextEncoder().encode(key).byteLength > MAX_STRING_BYTES) throw new Error('cognitum spaces: response key exceeds bound');
+      const normalized = key.replace(/[^a-z0-9]/gi, '').toLowerCase();
+      if (FORBIDDEN_FIELDS.has(normalized)) throw new Error('cognitum spaces: forbidden raw field');
+      visit(child, depth + 1);
+    }
+  };
+  visit(value, 0);
+}
+
 function forbiddenRawField(value: unknown): boolean {
   if (Array.isArray(value)) return value.some(forbiddenRawField);
   if (!record(value)) return false;
   return Object.entries(value).some(([key, child]) => {
     const normalized = key.replace(/[^a-z0-9]/gi, '').toLowerCase();
-    return ['rawcsi', 'cir', 'rftensors', 'recordings', 'poseframes', 'vitalwaveforms', 'identityobservations'].includes(normalized)
+    return FORBIDDEN_FIELDS.has(normalized)
       || forbiddenRawField(child);
   });
 }
 
 export function validateSpacesResult(value: unknown): SpacesListResult {
+  assertBoundedSemantic(value);
   if (!record(value) || value.object !== 'list' || !Array.isArray(value.data) || value.data.length > MAX_SPACES) {
     throw new Error('cognitum spaces: invalid list envelope');
   }
@@ -280,6 +410,70 @@ export function validateSpacesResult(value: unknown): SpacesListResult {
     return item as unknown as CognitumSpaceTwin;
   });
   return { data, boundary: boundary as unknown as SpacesBoundary };
+}
+
+/** Independently validate the versioned Cognitum API ADR-101 list contract. */
+export function validateSpatialResult(value: unknown, expectedKind: SpatialKind): SpatialListResult {
+  assertBoundedSemantic(value);
+  if (!record(value) || value.object !== 'list' || value.kind !== expectedKind
+    || value.schemaVersion !== '1.0' || !Array.isArray(value.data) || value.data.length > MAX_SPACES) {
+    throw new Error('cognitum spaces: invalid spatial list envelope');
+  }
+  const boundary = value.boundary;
+  if (!record(boundary) || boundary.authoritativeState !== 'HomeCore Edge'
+    || !Array.isArray(boundary.excluded)
+    || REQUIRED_EXCLUSIONS.some((required) => !(boundary.excluded as unknown[]).includes(required))) {
+    throw new Error('cognitum spaces: invalid spatial list envelope');
+  }
+  if (value.nextCursor !== null && value.nextCursor !== undefined
+    && (typeof value.nextCursor !== 'string' || !value.nextCursor || value.nextCursor.length > 512)) {
+    throw new Error('cognitum spaces: invalid spatial cursor');
+  }
+  const data = value.data.map((item): CognitumSpatialResource => {
+    if (!record(item) || !ID_RE.test(String(item.id ?? ''))
+      || typeof item.tenantId !== 'string' || !item.tenantId
+      || !UUID_RE.test(String(item.workspaceId ?? ''))
+      || item.kind !== expectedKind || item.schemaVersion !== '1.0'
+      || (item.privacy !== 'P2' && item.privacy !== 'P3')
+      || !ID_RE.test(String(item.messageId ?? ''))
+      || !Number.isSafeInteger(item.eventSequence) || Number(item.eventSequence) < 0
+      || !Number.isSafeInteger(item.version) || Number(item.version) < 1
+      || typeof item.observedAt !== 'string' || !Number.isFinite(Date.parse(item.observedAt))
+      || !record(item.attributes) || !record(item.provenance)) {
+      throw new Error('cognitum spaces: invalid spatial resource');
+    }
+    if (item.confidence !== null && item.confidence !== undefined
+      && (typeof item.confidence !== 'number' || !Number.isFinite(item.confidence)
+        || item.confidence < 0 || item.confidence > 1)) {
+      throw new Error('cognitum spaces: invalid confidence');
+    }
+    const required = (field: string): boolean => typeof item[field] === 'string' && Boolean(item[field]);
+    if (expectedKind !== 'sites' && !required('siteId')) throw new Error('cognitum spaces: incomplete hierarchy');
+    if (expectedKind === 'floors' && !required('buildingId')) throw new Error('cognitum spaces: incomplete hierarchy');
+    if (expectedKind === 'spaces' && (!required('buildingId') || !required('floorId'))) {
+      throw new Error('cognitum spaces: incomplete hierarchy');
+    }
+    if (['zones', 'entities', 'events', 'alerts'].includes(expectedKind) && !required('spaceId')) {
+      throw new Error('cognitum spaces: incomplete hierarchy');
+    }
+    if (expectedKind === 'entities'
+      && (!['sensor', 'person', 'object', 'track'].includes(String(item.entityType))
+        || (['person', 'track'].includes(String(item.entityType)) && item.identityMode !== 'anonymous'))) {
+      throw new Error('cognitum spaces: invalid entity privacy contract');
+    }
+    if (expectedKind === 'events' && !required('eventType')) throw new Error('cognitum spaces: invalid event contract');
+    if (expectedKind === 'alerts'
+      && (!required('alertType') || !['info', 'warning', 'critical'].includes(String(item.severity))
+        || !['open', 'acknowledged', 'resolved'].includes(String(item.status)))) {
+      throw new Error('cognitum spaces: invalid alert contract');
+    }
+    return item as unknown as CognitumSpatialResource;
+  });
+  return {
+    object: 'list', kind: expectedKind, schemaVersion: '1.0', data,
+    nextCursor: typeof value.nextCursor === 'string' ? value.nextCursor : null,
+    boundary: boundary as unknown as SpacesBoundary,
+  };
 }
 
 /** Cognitum privacy (P2/P3, the cloud-bridged tiers) → radio-moe PrivacyClass. */
@@ -317,6 +511,40 @@ export function spacesEnvelopeToObservation(env: CognitumSpacesEnvelope): Observ
       messageId: env.messageId,
       sequence: env.sequence,
       provenance: env.provenance,
+      derived: true,
+    },
+  };
+}
+
+/**
+ * Map a versioned resource into the same derived-observation admission seam.
+ * Missing source/calibration/expiry stays missing, deliberately causing
+ * `admitObservation` to reject rather than inventing authority from cloud state.
+ */
+export function spatialResourceToObservation(resource: CognitumSpatialResource): Observation {
+  const sourceId = typeof resource.provenance.sourceId === 'string'
+    ? resource.provenance.sourceId : '';
+  const calibrationVersion = typeof resource.provenance.modelVersion === 'string'
+    ? resource.provenance.modelVersion : '';
+  const provenance = typeof resource.provenance.digest === 'string'
+    ? resource.provenance.digest : '';
+  const kind = resource.eventType ?? resource.alertType ?? `${resource.kind}.state`;
+  return {
+    sourceId,
+    location: resource.spaceId ?? resource.siteId ?? resource.id,
+    kind,
+    value: resource.attributes,
+    confidence: typeof resource.confidence === 'number' ? resource.confidence : Number.NaN,
+    privacyClass: privacyOf(resource.privacy),
+    calibrationVersion,
+    issuedAt: toEpoch(resource.observedAt),
+    expiresAt: resource.expiresAt ? toEpoch(resource.expiresAt) : 0,
+    lineage: {
+      origin: 'cognitum-spaces',
+      tenantId: resource.tenantId,
+      messageId: resource.messageId,
+      sequence: resource.eventSequence,
+      provenance,
       derived: true,
     },
   };

--- a/packages/radio-moe/src/index.ts
+++ b/packages/radio-moe/src/index.ts
@@ -260,6 +260,7 @@ export { TlsPeerNode, tlsSendEnvelope, TlsConnection } from './tls-transport.js'
 export {
   CognitumSpacesClient,
   spacesEnvelopeToObservation,
+  spatialResourceToObservation,
   privacyOf,
   apiKeyAuth,
   bearerAuth,
@@ -267,10 +268,16 @@ export {
   type CognitumAuth,
   type CognitumSpacesConfig,
   type CognitumSpaceTwin,
+  type CognitumSpatialResource,
+  type SpatialKind,
+  type SpatialPageRequest,
+  type SpatialListResult,
   type CognitumSpacesEnvelope,
   type SpacesBoundary,
   type SpacesListResult,
   type CognitumFetchLike,
+  SPATIAL_KINDS,
+  validateSpatialResult,
 } from './cognitum-spaces.js';
 
 // Cognitum identity CLI session exchange (ADR-093). Its `cognitum-cli` token is

--- a/packages/radio-moe/test/cognitum-spaces.test.ts
+++ b/packages/radio-moe/test/cognitum-spaces.test.ts
@@ -7,12 +7,14 @@ import assert from 'node:assert/strict';
 import {
   CognitumSpacesClient,
   spacesEnvelopeToObservation,
+  spatialResourceToObservation,
   privacyOf,
   apiKeyAuth,
   bearerAuth,
   admitObservation,
   confidenceTier,
   type CognitumSpacesEnvelope,
+  type CognitumSpatialResource,
   type CognitumFetchLike,
 } from '../src/index.js';
 
@@ -66,7 +68,9 @@ test('privacy tiers and missing calibration are fail-closed downstream', () => {
 test('auth headers: cog_ key vs Bearer, read at call time', () => {
   assert.deepEqual(apiKeyAuth(() => 'cog_abc')(), { 'x-api-key': 'cog_abc' });
   assert.deepEqual(apiKeyAuth(() => undefined)(), {});
+  assert.deepEqual(apiKeyAuth(() => 'cog_bad\r\nheader')(), {});
   assert.deepEqual(bearerAuth(() => 'idtok')(), { authorization: 'Bearer idtok' });
+  assert.deepEqual(bearerAuth(() => 'bad token')(), {});
 });
 
 test('listSpaces parses the real {object:list, data, boundary} shape + auth (injected fetch)', async () => {
@@ -94,6 +98,78 @@ test('listSpaces parses the real {object:list, data, boundary} shape + auth (inj
   assert.equal(seen[0]!.headers['x-api-key'], 'cog_xyz');
   // legacy convenience: listSpaces() returns just the data array
   assert.equal((await client.listSpaces()).length, 1);
+});
+
+test('versioned hierarchy/events are paged and remain derived evidence', async () => {
+  const seen: string[] = [];
+  const event: CognitumSpatialResource = {
+    id: 'event-1', tenantId: 'tenant-1', workspaceId: '11111111-1111-4111-8111-111111111111',
+    kind: 'events', schemaVersion: '1.0', privacy: 'P2', messageId: 'message-1',
+    eventSequence: 7, version: 1, siteId: 'site-1', spaceId: 'room-1',
+    eventType: 'occupancy.changed', observedAt: '2026-08-19T10:00:00Z',
+    expiresAt: '2026-08-19T10:01:00Z', confidence: 0.8,
+    attributes: { occupancy: 2 },
+    provenance: { sourceId: 'sensor-1', modelVersion: 'cal-1', digest: 'witness-1' },
+  };
+  const fake: CognitumFetchLike = async (url) => {
+    seen.push(url);
+    return {
+      ok: true, status: 200,
+      text: async () => JSON.stringify({
+        object: 'list', kind: 'events', schemaVersion: '1.0', data: [event], nextCursor: 'next-1',
+        boundary: { authoritativeState: 'HomeCore Edge', excluded: [...REQUIRED_EXCLUSIONS_FOR_TEST] },
+      }),
+      json: async () => ({}),
+    };
+  };
+  const client = new CognitumSpacesClient({
+    baseUrl: 'https://gw.example', auth: bearerAuth(() => 'ruview-oauth'), fetchImpl: fake,
+  });
+  const result = await client.listSpatial('events', { limit: 25, cursor: 'prior' });
+  assert.equal(result.data[0]!.eventType, 'occupancy.changed');
+  assert.equal(result.nextCursor, 'next-1');
+  assert.equal(seen[0], 'https://gw.example/v1/spatial/events?limit=25&cursor=prior');
+
+  const observation = spatialResourceToObservation(event);
+  assert.ok(observation.lineage);
+  assert.equal(observation.lineage.derived, true);
+  assert.equal(observation.lineage.messageId, 'message-1');
+  assert.equal(admitObservation(observation, Date.parse('2026-08-19T10:00:30Z')).admissible, true);
+  assert.notEqual(confidenceTier(observation), 'authorized-workflow');
+});
+
+test('versioned client binds API keys to a UUID workspace and validates kind-specific privacy', async () => {
+  const never: CognitumFetchLike = async () => { throw new Error('must not fetch'); };
+  const client = new CognitumSpacesClient({ auth: apiKeyAuth(() => 'cog_key'), fetchImpl: never });
+  await assert.rejects(() => client.listSpatial('sites'), /require workspace id/);
+  await assert.rejects(
+    () => client.listSpatial('sites', { workspaceId: 'not-a-uuid' }),
+    /invalid workspace id/,
+  );
+  await assert.rejects(
+    () => client.listSpatial('sites', { workspaceId: '11111111-1111-7111-8111-111111111111' }),
+    /must not fetch/,
+  );
+
+  const invalidEntity = {
+    object: 'list', kind: 'entities', schemaVersion: '1.0', nextCursor: null,
+    boundary: { authoritativeState: 'HomeCore Edge', excluded: [...REQUIRED_EXCLUSIONS_FOR_TEST] },
+    data: [{
+      id: 'person-1', tenantId: 'tenant-1', workspaceId: '11111111-1111-4111-8111-111111111111',
+      kind: 'entities', schemaVersion: '1.0', privacy: 'P2', messageId: 'm-1',
+      eventSequence: 1, version: 1, siteId: 'site-1', spaceId: 'space-1',
+      entityType: 'person', identityMode: 'named', observedAt: '2026-08-19T10:00:00Z',
+      attributes: {}, provenance: {},
+    }],
+  };
+  const response: CognitumFetchLike = async () => ({
+    ok: true, status: 200, text: async () => JSON.stringify(invalidEntity), json: async () => ({}),
+  });
+  const oauth = new CognitumSpacesClient({ auth: bearerAuth(() => 'token'), fetchImpl: response });
+  await assert.rejects(() => oauth.listSpatial('entities'), /entity privacy contract/);
+  invalidEntity.data[0]!.identityMode = 'anonymous';
+  (invalidEntity.data[0] as Record<string, unknown>).attributes = { packet_capture: 'raw' };
+  await assert.rejects(() => oauth.listSpatial('entities'), /forbidden raw field/);
 });
 
 test('client rejects unsafe URLs, limits, and ambiguous credentials', async () => {


### PR DESCRIPTION
## Summary

- extend `CognitumSpacesClient` with strict paged reads for the versioned hierarchy, anonymous entities, events, and alerts
- preserve tenant/message/sequence lineage when mapping cloud state into fail-closed derived observations
- harden credential, URL, redirect, media-type, byte, nesting, raw-field, UUID, hierarchy, timestamp, and confidence validation
- add a complete end-user guide and update ADR-402
- bump `radio-moe` to 0.3.0 and add a main-only provenance-enabled npm release workflow with exact-artifact smoke testing

## Validation

- TypeScript typecheck: green
- package tests: 145 pass, two intentionally skipped live/environment gates
- build: green
- `npm audit --omit=optional`: zero findings
- `npm pack --dry-run`: green; the Cognitum guide and built exports are present
- changed-file credential/secret pattern scan: zero hits

The adapter remains read-only and exposes no write, approval, command, or actuator method. The versioned live probe remains gated until the API PR is deployed.

Closes #6