### PR TITLE
fix(radio-moe): bind npm provenance repository

### DIFF
--- a/packages/radio-moe/package.json
+++ b/packages/radio-moe/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "license": "MIT",
   "author": "rUv",
+  "repository": "https://github.com/ruvnet/autogenous",
   "keywords": [
     "mixture-of-experts",
     "moe",

--- a/packages/radio-moe/test/package-metadata.test.ts
+++ b/packages/radio-moe/test/package-metadata.test.ts
@@ -1,0 +1,11 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('package repository matches GitHub Actions provenance identity', async () => {
+  const packageJson = JSON.parse(
+    await readFile(new URL('../package.json', import.meta.url), 'utf8'),
+  ) as { repository?: unknown };
+
+  assert.equal(packageJson.repository, 'https://github.com/ruvnet/autogenous');
+});


### PR DESCRIPTION
## Summary
- add the canonical GitHub repository identity required by npm provenance verification
- add a regression test that pins the package metadata to the Actions provenance repository

## Validation
- `npm run typecheck`
- `npm test`
- `npm audit --audit-level=high`
- `npm pack --dry-run --json`
- `git diff --check`

Fixes the concrete E422 observed in release run 32284559852. Publication remains main-only and workflow-only.